### PR TITLE
Remove redundant datetime import

### DIFF
--- a/trading_bot.py
+++ b/trading_bot.py
@@ -6,7 +6,6 @@ import hashlib
 import base64
 import time
 import requests
-from datetime import datetime
 from typing import Dict, List, Optional
 import pandas as pd
 import numpy as np


### PR DESCRIPTION
## Summary
- remove duplicate datetime import in trading_bot

## Testing
- `python -m py_compile trading_bot.py`


------
https://chatgpt.com/codex/tasks/task_e_689f359205888321816385777f0dd6e6